### PR TITLE
bug fix for ancombc2 when a similar function with model.matrix function is loaded from AlgDesign package

### DIFF
--- a/R/ancombc2.R
+++ b/R/ancombc2.R
@@ -449,7 +449,7 @@ ancombc2 = function(data, taxa_are_rows = TRUE,
 
     # 2. Estimation of the sample-specific biases
     options(na.action = "na.pass") # Keep NA's in rows of x
-    x = model.matrix(formula(paste0("~", fix_formula)), data = as.data.frame(meta_data))
+    x = stats::model.matrix(formula(paste0("~", fix_formula)), data = meta_data)
     options(na.action = "na.omit") # Switch it back
     fix_eff = colnames(x)
     n_fix_eff = length(fix_eff)

--- a/R/ancombc2.R
+++ b/R/ancombc2.R
@@ -449,7 +449,7 @@ ancombc2 = function(data, taxa_are_rows = TRUE,
 
     # 2. Estimation of the sample-specific biases
     options(na.action = "na.pass") # Keep NA's in rows of x
-    x = model.matrix(formula(paste0("~", fix_formula)), data = meta_data)
+    x = model.matrix(formula(paste0("~", fix_formula)), data = as.data.frame(meta_data))
     options(na.action = "na.omit") # Switch it back
     fix_eff = colnames(x)
     n_fix_eff = length(fix_eff)


### PR DESCRIPTION
When the AlgDesign package is loaded, its model.matrix function interferes with the model.matrix from the stats package used in the ancombc2 function, making it unable to recognize data formats similar to data.frame. It is fixed by using stats::model.matrix to avoid wrong call.