### PR TITLE
Correct passing of arguments to Winsorize.

### DIFF
--- a/R/sparse_dist.R
+++ b/R/sparse_dist.R
@@ -27,7 +27,7 @@
 
     # Winsorization
     mat = apply(mat, 2, function(x)
-        DescTools::Winsorize(x, probs = wins_quant, na.rm = TRUE))
+        DescTools::Winsorize(x, val = quantile(x, probs = wins_quant, na.rm = TRUE)))
 
     # Co-occurrence matrix
     mat_occur = mat

--- a/R/sparse_dist.R
+++ b/R/sparse_dist.R
@@ -27,7 +27,7 @@
 
     # Winsorization
     mat = apply(mat, 2, function(x)
-        DescTools::Winsorize(x, val = quantile(x, probs = wins_quant, na.rm = TRUE)))
+        DescTools::Winsorize(x, val = stats::quantile(x, probs = wins_quant, na.rm = TRUE)))
 
     # Co-occurrence matrix
     mat_occur = mat

--- a/R/sparse_linear.R
+++ b/R/sparse_linear.R
@@ -38,7 +38,7 @@
 
     # Winsorization
     mat = apply(mat, 2, function(x)
-        DescTools::Winsorize(x, val = quantile(x, probs = wins_quant, na.rm = TRUE)))
+        DescTools::Winsorize(x, val = stats::quantile(x, probs = wins_quant, na.rm = TRUE)))
 
     # Co-occurrence matrix
     mat_occur = mat

--- a/R/sparse_linear.R
+++ b/R/sparse_linear.R
@@ -38,7 +38,7 @@
 
     # Winsorization
     mat = apply(mat, 2, function(x)
-        DescTools::Winsorize(x, probs = wins_quant, na.rm = TRUE))
+        DescTools::Winsorize(x, val = quantile(x, probs = wins_quant, na.rm = TRUE)))
 
     # Co-occurrence matrix
     mat_occur = mat


### PR DESCRIPTION
In sparse_linear and sparse_dist, DescTools::Winsorize is now called with` quantile(x, probs = wins_quant, na.rm = TRUE)`. This should resolve #278.